### PR TITLE
In D3CalendarViewComponent, changed the alias of the property "cccTooltipFormat" to "tooltipFormat".

### DIFF
--- a/dashboards/CalendarView.cdfde
+++ b/dashboards/CalendarView.cdfde
@@ -469,7 +469,7 @@
      },
      {
       "name": "html",
-      "value": "<p>\n    Calendar view that displays an yearly grid\n</p> \n\n\n<h3>Author</h3>\n\nPedro Alves - Webdetails\n\n\n<h3>Result Set</h3>\n\n<div class=\"well\"><p>\n\nThis visualization equires a resultset with 2 columns, one for the date in \n'yyyy-mm-dd' format and other for the numeric value\n\n<table class=\"resultsetTable\">\n    <tr><th>Column</th><th>Description</th><th>Name required?</th></tr>\n    \n    <tr><td>date</td><td>Date string in 'yyyy-mm-dd' format</td><td>No</td></tr>    \n    <tr><td>value</td><td>The numerical value</td><td>No</td></tr>    \n    \n</table>\n\n\n</p></div>\n\n\n\n<h3>Options</h3>\n \n<div class=\"well\"><p>\n    \n    Here are the specific options to add to the generic CDF options:\n    \n    <dl>\n        <dt>width</dt>\n        <dd>If given, will be used. If not, visualization will adapt to the \n            available container\n        </dd>  \n        <dt>cccTooltipFormat</dt>\n        <dd>Optional function to control the tooltip format. Receives \n            two arguments: <i>date</i> and <i>value</i>\n        </dd>  \n    </dl>\n    \n</p></div>\n \n\n<h3>Visualization Information</h3>\n\n<div class=\"well\"><p>\n\n\nCode was taken from \n<a href=\"http://bl.ocks.org/mbostock/raw/3885705/\">original example</a>. All\ncredits to the original author. Some modifications were made to this code:\n\n<ul>\n    <li>Replaced the datasource call to get the data from the endpoints</li>\n    <li>Width is passed from the component options</li>\n    <li>Height is calculated from width</li>\n    <li>Tooltip can optionally be formatted</li>\n</ul>\n\nThe array of colors is fixed, but can be overriden by simple CSS. The default\nis:\n\n<blockquote>\n    <pre>\n\nsvg .day {\n  fill: #fff;\n  stroke: #ccc;\n}\n\nsvg .month {\n  fill: none;\n  stroke: #000;\n  stroke-width: 2px;\n}\n\n.RdYlGn .q0-11{fill:rgb(165,0,38)}\n.RdYlGn .q1-11{fill:rgb(215,48,39)}\n.RdYlGn .q2-11{fill:rgb(244,109,67)}\n.RdYlGn .q3-11{fill:rgb(253,174,97)}\n.RdYlGn .q4-11{fill:rgb(254,224,139)}\n.RdYlGn .q5-11{fill:rgb(255,255,191)}\n.RdYlGn .q6-11{fill:rgb(217,239,139)}\n.RdYlGn .q7-11{fill:rgb(166,217,106)}\n.RdYlGn .q8-11{fill:rgb(102,189,99)}\n.RdYlGn .q9-11{fill:rgb(26,152,80)}\n.RdYlGn .q10-11{fill:rgb(0,104,55)} \n    \n</pre>\n</blockquote> \n\n</p></div> ",
+      "value": "<p>\n    Calendar view that displays an yearly grid\n</p> \n\n\n<h3>Author</h3>\n\nPedro Alves - Webdetails\n\n\n<h3>Result Set</h3>\n\n<div class=\"well\"><p>\n\nThis visualization requires a resultset with 2 columns, one for the date in \n'yyyy-mm-dd' format and other for the numeric value\n\n<table class=\"resultsetTable\">\n    <tr><th>Column</th><th>Description</th><th>Name required?</th></tr>\n    \n    <tr><td>date</td><td>Date string in 'yyyy-mm-dd' format</td><td>No</td></tr>    \n    <tr><td>value</td><td>The numerical value</td><td>No</td></tr>    \n    \n</table>\n\n\n</p></div>\n\n\n\n<h3>Options</h3>\n \n<div class=\"well\"><p>\n    \n    Here are the specific options to add to the generic CDF options:\n    \n    <dl>\n        <dt>width</dt>\n        <dd>If given, will be used. If not, visualization will adapt to the \n            available container\n        </dd>  \n        <dt>tooltipFormat</dt>\n        <dd>Optional function to control the tooltip format. Receives \n            two arguments: <i>date</i> and <i>value</i>\n        </dd>  \n    </dl>\n    \n</p></div>\n \n\n<h3>Visualization Information</h3>\n\n<div class=\"well\"><p>\n\n\nCode was taken from \n<a href=\"http://bl.ocks.org/mbostock/raw/3885705/\">original example</a>. All\ncredits to the original author. Some modifications were made to this code:\n\n<ul>\n    <li>Replaced the datasource call to get the data from the endpoints</li>\n    <li>Width is passed from the component options</li>\n    <li>Height is calculated from width</li>\n    <li>Tooltip can optionally be formatted</li>\n</ul>\n\nThe array of colors is fixed, but can be overriden by simple CSS. The default\nis:\n\n<blockquote>\n    <pre>\n\nsvg .day {\n  fill: #fff;\n  stroke: #ccc;\n}\n\nsvg .month {\n  fill: none;\n  stroke: #000;\n  stroke-width: 2px;\n}\n\n.RdYlGn .q0-11{fill:rgb(165,0,38)}\n.RdYlGn .q1-11{fill:rgb(215,48,39)}\n.RdYlGn .q2-11{fill:rgb(244,109,67)}\n.RdYlGn .q3-11{fill:rgb(253,174,97)}\n.RdYlGn .q4-11{fill:rgb(254,224,139)}\n.RdYlGn .q5-11{fill:rgb(255,255,191)}\n.RdYlGn .q6-11{fill:rgb(217,239,139)}\n.RdYlGn .q7-11{fill:rgb(166,217,106)}\n.RdYlGn .q8-11{fill:rgb(102,189,99)}\n.RdYlGn .q9-11{fill:rgb(26,152,80)}\n.RdYlGn .q10-11{fill:rgb(0,104,55)} \n    \n</pre>\n</blockquote> \n\n</p></div> ",
       "type": "Html"
      },
      {
@@ -533,7 +533,7 @@
    {
     "id": "24c772c1-f923-996d-6287-fa20350b8dfe",
     "type": "Componentsd3CalendarView",
-    "typeDesc": "D3 Calendar View Component",
+    "typeDesc": "d3 Calendar View Component",
     "parent": "D3COMPONENTS",
     "properties": [
      {
@@ -612,8 +612,8 @@
       "type": "Html"
      },
      {
-      "name": "cccTooltipFormat",
-      "value": "function f(d,v){\n  return \"Date: \" + d +\"; Value: \" + v;   \n}",
+      "name": "tooltipFormat",
+      "value": "function f(d,v) {\n  return \"Date: \" + d + \"; Value: \" + (100 * v).toFixed(1) + \"%\";\n}",
       "type": "JavaScript"
      }
     ]

--- a/resources/components/d3CalendarView/component.xml
+++ b/resources/components/d3CalendarView/component.xml
@@ -3,7 +3,7 @@
   <Header>
     <Name>d3 CalendarView</Name>
     <IName>d3CalendarView</IName>
-    <Description>D3 Calendar View Component</Description>
+    <Description>d3 Calendar View Component</Description>
     <Category>D3COMPONENTS</Category>
     <CatDescription>D3 Components</CatDescription>
     <Type>PalleteEntry</Type>
@@ -13,7 +13,6 @@
     <Model>
       <!-- Component specific options -->
       <Property>width</Property>
-      <Property>cccTooltipFormat</Property>
       <!-- Leave this ones for every component -->
       <Definition name="chartDefinition">
           <Property>dataSource</Property>
@@ -27,6 +26,7 @@
       <Property>preExecution</Property>
       <Property>postExecution</Property>
       <Property>tooltip</Property>
+      <Property name="tooltipFormat">cccTooltipFormat</Property>
       <Property>listeners</Property>
       <Property>refreshPeriod</Property>
     </Model>
@@ -40,19 +40,6 @@
         <Dependency src="../commons/d3ComponentBase.js" version="1">d3ComponentBase</Dependency>
       </Dependencies>
       <CustomProperties>
-		<!-- <DesignerProperty>
-		  <Header>
-		    <Name>inputFormat</Name>
-		    <Parent>BaseProperty</Parent>
-		    <DefaultValue>YYYY-MM-DD</DefaultValue>
-		    <Description>Input format</Description>
-		    <Tooltip>Input date format as used by moment.js</Tooltip>
-		    <InputType>String</InputType>
-		    <OutputType>String</OutputType>
-		    <Order>30</Order>
-		    <Version>1.0</Version>
-		  </Header>
-		</DesignerProperty> -->
 	  </CustomProperties>
     </Implementation>
   </Contents>

--- a/resources/components/d3CalendarView/d3CalendarView.js
+++ b/resources/components/d3CalendarView/d3CalendarView.js
@@ -1,5 +1,5 @@
 /*
- * d3 component, using the chartComponent
+ * d3 Calendar View, using the D3ComponentBase
  */
 
 var D3CalendarViewComponent = D3ComponentBase.extend({
@@ -7,7 +7,8 @@ var D3CalendarViewComponent = D3ComponentBase.extend({
   defaultWidth: 600,
   defaultHeight: 136,
   cellSize: 17,
-  _formattingFunction: function(d, v) {
+
+  _defaultTooltipFormat: function(d, v) {
     return d + ": " + v;
   },
 
@@ -47,7 +48,6 @@ var D3CalendarViewComponent = D3ComponentBase.extend({
 
     var day = d3.time.format("%w"),
             week = d3.time.format("%U"),
-            percent = d3.format(".1%"),
             format = d3.time.format("%Y-%m-%d");
 
     var color = d3.scale.quantize()
@@ -121,6 +121,7 @@ var D3CalendarViewComponent = D3ComponentBase.extend({
     });
 
     var formattingFunction = this.cccTooltipFormat||this._formattingFunction;
+    var tooltipFormat = this.tooltipFormat || this._defaultTooltipFormat;
 
     rect.filter(function(d) {
       return d in dataIndexed;
@@ -131,6 +132,7 @@ var D3CalendarViewComponent = D3ComponentBase.extend({
             .select("title")
             .text(function(d) {
       return formattingFunction(d,dataIndexed[d]);
+          return tooltipFormat(d, dataIndexed[d]); 
     });
     
        //      });


### PR DESCRIPTION
- Removed the unused percent variable.
- Added percent formatting to the custom "tooltipFormat" function of the documentation dashboard.
- Fixed some typos.

@pmalves please review.
