### PR TITLE
Build properties for Pentaho versions 7.x

### DIFF
--- a/build.properties
+++ b/build.properties
@@ -1,13 +1,13 @@
 # project properties
 project.id=d3ComponentLibrary
-project.revision=14.06.18
+project.revision=17.07.24
 project.stage=RELEASE
-project.version=14.06.18
+project.version=17.07.24
 # ivy properties
 impl.title=D3 component library, to be used with Ctools and Analyzer
 ivy.artifact.group=webdetails
 ivy.artifact.id=d3ComponentLibrary
-cpf.pentaho.artifact=cpf-pentaho5
-dependency.cpf.revision=14.06.18
+cpf.pentaho.artifact=cpf-pentaho
+dependency.cpf.revision=7.0.0.0-25
 cpk.pentaho.artifact=cpk-pentaho5
-dependency.cpk.revision=14.06.18
+dependency.cpk.revision=7.0.0.0-25


### PR DESCRIPTION
Updated build properties to reflect new libraries versions for cpf and cpk. This was done to allow plugin installation on Pentaho 7.x versions.